### PR TITLE
Control image size on bigger screens

### DIFF
--- a/themes/rtd_qgis/static/css/qgis_docs.css
+++ b/themes/rtd_qgis/static/css/qgis_docs.css
@@ -42,8 +42,16 @@
   position: fixed
 }
 
+/* Widen space for the documentation content*/
 .wy-nav-content {
 	max-width: 1260px;
+}
+
+/* Avoid images being too big on bigger screen*/
+@media screen and (min-width: 767px) {
+  .rst-content .img {
+    max-width: 70%
+  }
 }
 
 /* override table width restrictions 


### PR DESCRIPTION
With widening the documentation text, we also have make screenshots look bigger. Too much bigger. See for example https://docs.qgis.org/testing/en/docs/user_manual/style_library/label_settings.html#figure-labels-placement-polygon

Here's an attempt to fix that. Why those values? No idea. Need to be tested.
We have  now
![image](https://user-images.githubusercontent.com/7983394/83621370-e12d4180-a58e-11ea-9bec-3bb924e22abb.png)

vs PR should render something like
![Capture d’écran 2020-06-03 à 11 37 37](https://user-images.githubusercontent.com/7983394/83621301-c8249080-a58e-11ea-8f1f-a9e006936af8.png)
